### PR TITLE
SEC-52: Add a SQL function regex_replace

### DIFF
--- a/docs/wiki/introduction/sql.md
+++ b/docs/wiki/introduction/sql.md
@@ -195,6 +195,7 @@ String parsing functions are always helpful, some help within subqueries so they
 
 - `split(COLUMN, TOKENS, INDEX)`: split `COLUMN` using any character token from `TOKENS` and return the `INDEX` result. If an `INDEX` result does not exist, a `NULL` type is returned.
 - `regex_split(COLUMN, PATTERN, INDEX)`: similar to split, but instead of `TOKENS`, apply the POSIX regex `PATTERN` (as interpreted by boost::regex).
+- `regex_replace(COLUMN, PATTERN, NEW_SUBSTRING)`: replace into `COLUMN` all substings that match the POSIX regex `PATTERN` (as interpreted by boost::regex) by `NEW_SUBSTRING`.
 - `inet_aton(IPv4_STRING)`: return the integer representation of an IPv4 string.
 
 **Hashing functions**

--- a/docs/wiki/introduction/sql.md
+++ b/docs/wiki/introduction/sql.md
@@ -195,7 +195,7 @@ String parsing functions are always helpful, some help within subqueries so they
 
 - `split(COLUMN, TOKENS, INDEX)`: split `COLUMN` using any character token from `TOKENS` and return the `INDEX` result. If an `INDEX` result does not exist, a `NULL` type is returned.
 - `regex_split(COLUMN, PATTERN, INDEX)`: similar to split, but instead of `TOKENS`, apply the POSIX regex `PATTERN` (as interpreted by boost::regex).
-- `regex_replace(COLUMN, PATTERN, NEW_SUBSTRING)`: replace into `COLUMN` all substings that match the POSIX regex `PATTERN` (as interpreted by boost::regex) by `NEW_SUBSTRING`.
+- `regex_replace(COLUMN, PATTERN, NEW_SUBSTRING)`: replace into `COLUMN` all substrings that match the POSIX regex `PATTERN` (as interpreted by boost::regex) by `NEW_SUBSTRING`.
 - `inet_aton(IPv4_STRING)`: return the integer representation of an IPv4 string.
 
 **Hashing functions**

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -161,7 +161,7 @@ static void callStringReplaceFunc(sqlite3_context* context,
   std::string find_string((char*)sqlite3_value_text(argv[1]));
   std::string replace_with((char*)sqlite3_value_text(argv[2]));
   if (find_string.empty()) {
-    // Allow the input string to be empty.
+    // Check if the substring to find is empty.
     sqlite3_result_error(context, "Invalid input to replace function", -1);
     return;
   }

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -33,8 +33,10 @@ namespace osquery {
 using SplitResult = std::vector<std::string>;
 using StringSplitFunction = std::function<SplitResult(
     const std::string& input, const std::string& tokens)>;
-using StringReplaceFunction = std::function<std::string(
-    const std::string& input, const std::string& find_string, const std::string& replace_with)>;
+using StringReplaceFunction =
+    std::function<std::string(const std::string& input,
+                              const std::string& find_string,
+                              const std::string& replace_with)>;
 
 /**
  * @brief A simple SQLite column string split implementation.
@@ -80,13 +82,14 @@ static SplitResult regexSplit(const std::string& input,
 /**
  * @brief A regex SQLite column string replace implementation.
  *
- * Search into a column value using a single or multi-character pattern and replace
- * with a new substring. The pattern input is considered a regex.
+ * Search into a column value using a single or multi-character pattern and
+ * replace with a new substring. The pattern input is considered a regex.
  *
  * Example:
  *   1. SELECT path FROM processes WHERE name='osqueryi' LIMIT 1;
  *      /Users/osquery_dev/workspace/osquery/build/darwin/osquery/osqueryi
- *   2. SELECT regex_replace(path, '/Users/[^/]+/', './') FROM processes WHERE name='osqueryi' LIMIT 1;
+ *   2. SELECT regex_replace(path, '/Users/[^/]+/', './') FROM processes WHERE
+ * name='osqueryi' LIMIT 1;
  *      ./workspace/osquery/build/darwin/osquery/osqueryi
  */
 static std::string regexReplace(const std::string& input,

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -79,6 +79,7 @@ static SplitResult regexSplit(const std::string& input,
   boost::algorithm::split_regex(result, input, boost::regex(token));
   return result;
 }
+
 /**
  * @brief A regex SQLite column string replace implementation.
  *

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <boost/algorithm/string/regex.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/regex.hpp>
 
 #include "osquery/core/conversions.h"
@@ -32,6 +33,8 @@ namespace osquery {
 using SplitResult = std::vector<std::string>;
 using StringSplitFunction = std::function<SplitResult(
     const std::string& input, const std::string& tokens)>;
+using StringReplaceFunction = std::function<std::string(
+    const std::string& input, const std::string& find_string, const std::string& replace_with)>;
 
 /**
  * @brief A simple SQLite column string split implementation.
@@ -73,6 +76,23 @@ static SplitResult regexSplit(const std::string& input,
   std::vector<std::string> result;
   boost::algorithm::split_regex(result, input, boost::regex(token));
   return result;
+}
+/**
+ * @brief A regex SQLite column string replace implementation.
+ *
+ * Search into a column value using a single or multi-character pattern and replace
+ * with a new substring. The pattern input is considered a regex.
+ *
+ * Example:
+ *   1. SELECT path FROM processes WHERE name='osqueryi' LIMIT 1;
+ *      /Users/osquery_dev/workspace/osquery/build/darwin/osquery/osqueryi
+ *   2. SELECT regex_replace(path, '/Users/[^/]+/', './') FROM processes WHERE name='osqueryi' LIMIT 1;
+ *      ./workspace/osquery/build/darwin/osquery/osqueryi
+ */
+static std::string regexReplace(const std::string& input,
+                                const std::string& pattern,
+                                const std::string& replace_with) {
+  return boost::regex_replace(input, boost::regex(pattern), replace_with);
 }
 
 static void callStringSplitFunc(sqlite3_context* context,
@@ -124,6 +144,42 @@ static void regexStringSplitFunc(sqlite3_context* context,
   callStringSplitFunc(context, argc, argv, regexSplit);
 }
 
+static void callStringReplaceFunc(sqlite3_context* context,
+                                  int argc,
+                                  sqlite3_value** argv,
+                                  StringReplaceFunction f) {
+  assert(argc == 3);
+  if (SQLITE_NULL == sqlite3_value_type(argv[0]) ||
+      SQLITE_NULL == sqlite3_value_type(argv[1]) ||
+      SQLITE_NULL == sqlite3_value_type(argv[2])) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  // Parse and verify the replace input parameters.
+  std::string input((char*)sqlite3_value_text(argv[0]));
+  std::string find_string((char*)sqlite3_value_text(argv[1]));
+  std::string replace_with((char*)sqlite3_value_text(argv[2]));
+  if (find_string.empty()) {
+    // Allow the input string to be empty.
+    sqlite3_result_error(context, "Invalid input to replace function", -1);
+    return;
+  }
+
+  auto result = f(input, find_string, replace_with);
+
+  sqlite3_result_text(context,
+                      result.c_str(),
+                      static_cast<int>(result.size()),
+                      SQLITE_TRANSIENT);
+}
+
+static void regexStringReplaceFunc(sqlite3_context* context,
+                                   int argc,
+                                   sqlite3_value** argv) {
+  callStringReplaceFunc(context, argc, argv, regexReplace);
+}
+
 /**
  * @brief Convert an IPv4 string address to decimal.
  */
@@ -167,6 +223,14 @@ void registerStringExtensions(sqlite3* db) {
                           SQLITE_UTF8,
                           nullptr,
                           regexStringSplitFunc,
+                          nullptr,
+                          nullptr);
+  sqlite3_create_function(db,
+                          "regex_replace",
+                          3,
+                          SQLITE_UTF8,
+                          nullptr,
+                          regexStringReplaceFunc,
                           nullptr,
                           nullptr);
   sqlite3_create_function(db,

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -166,7 +166,7 @@ static void callStringReplaceFunc(sqlite3_context* context,
   std::string replace_with((char*)sqlite3_value_text(argv[2]));
   if (find_string.empty()) {
     // Check if the substring to find is empty.
-    sqlite3_result_error(context, "Invalid input to replace function", -1);
+    sqlite3_result_error(context, "Invalid substring to find in replace function", -1);
     return;
   }
 

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -154,4 +154,11 @@ TEST_F(SQLTests, test_sql_sha256) {
   EXPECT_EQ(d[0]["test"],
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 }
+
+TEST_F(SQLTests, test_sql_regex_replace) {
+  QueryData d;
+  query("select regex_replace('5 little monkeys climbing up 1 wall', '[0-9]', '-') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "- little monkeys climbing up - wall");
+}
 }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -155,10 +155,37 @@ TEST_F(SQLTests, test_sql_sha256) {
             "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 }
 
+TEST_F(SQLTests, test_sql_regex_split) {
+  QueryData d;
+  query("select regex_split('10-0.12.192', '[-\\.]', 1) as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "0");
+}
+
 TEST_F(SQLTests, test_sql_regex_replace) {
   QueryData d;
   query("select regex_replace('5 little monkeys climbing up 1 wall', '[0-9]', '-') as test;", d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "- little monkeys climbing up - wall");
+}
+
+TEST_F(SQLTests, test_sql_regex_replace_with_empty_pattern) {
+  QueryData d;
+  query("select regex_replace('5 little monkeys climbing up 1 wall', '', '-') as test;", d);
+  EXPECT_EQ(d.size(), 0);
+}
+
+TEST_F(SQLTests, test_sql_regex_replace_with_empty_input) {
+  QueryData d;
+  query("select regex_replace('', '[0-9]', '-') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "");
+}
+
+TEST_F(SQLTests, test_sql_regex_replace_without_match) {
+  QueryData d;
+  query("select regex_replace('Mama said the monkeys,not to fight|-selection_end', '[0-9]', '-') as test;", d);
+  EXPECT_EQ(d.size(), 1U);
+  EXPECT_EQ(d[0]["test"], "Mama said the monkeys,not to fight|-selection_end");
 }
 }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -191,10 +191,10 @@ TEST_F(SQLTests, test_sql_regex_replace_with_empty_input) {
 TEST_F(SQLTests, test_sql_regex_replace_without_match) {
   QueryData d;
   query(
-      "select regex_replace('Mama said the monkeys,not to "
-      "fight|-selection_end', '[0-9]', '-') as test;",
+      "select regex_replace('Mama said the monkeys,not to fight',"
+      " '[0-9]', '-') as test;",
       d);
   EXPECT_EQ(d.size(), 1U);
-  EXPECT_EQ(d[0]["test"], "Mama said the monkeys,not to fight|-selection_end");
+  EXPECT_EQ(d[0]["test"], "Mama said the monkeys,not to fight");
 }
 }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -157,43 +157,48 @@ TEST_F(SQLTests, test_sql_sha256) {
 
 TEST_F(SQLTests, test_sql_regex_split) {
   QueryData d;
-  query("select regex_split('10-0.12.192', '[-\\.]', 1) as test;", d);
+  auto result = query("select regex_split('10-0.12.192', '[-\\.]', 1) as test;", d);
+  EXPECT_TRUE(result.ok());
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "0");
 }
 
 TEST_F(SQLTests, test_sql_regex_replace) {
   QueryData d;
-  query(
+  auto result = query(
       "select regex_replace('5 little monkeys climbing up 1 wall', '[0-9]', "
       "'-') as test;",
       d);
+  EXPECT_TRUE(result.ok());
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "- little monkeys climbing up - wall");
 }
 
 TEST_F(SQLTests, test_sql_regex_replace_with_empty_pattern) {
   QueryData d;
-  query(
+  auto result = query(
       "select regex_replace('5 little monkeys climbing up 1 wall', '', '-') as "
       "test;",
       d);
+  EXPECT_FALSE(result.ok());
   EXPECT_EQ(d.size(), 0);
 }
 
 TEST_F(SQLTests, test_sql_regex_replace_with_empty_input) {
   QueryData d;
-  query("select regex_replace('', '[0-9]', '-') as test;", d);
+  auto result = query("select regex_replace('', '[0-9]', '-') as test;", d);
+  EXPECT_TRUE(result.ok());
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "");
 }
 
 TEST_F(SQLTests, test_sql_regex_replace_without_match) {
   QueryData d;
-  query(
+  auto result = query(
       "select regex_replace('Mama said the monkeys,not to fight',"
       " '[0-9]', '-') as test;",
       d);
+  EXPECT_TRUE(result.ok());
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "Mama said the monkeys,not to fight");
 }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -164,14 +164,20 @@ TEST_F(SQLTests, test_sql_regex_split) {
 
 TEST_F(SQLTests, test_sql_regex_replace) {
   QueryData d;
-  query("select regex_replace('5 little monkeys climbing up 1 wall', '[0-9]', '-') as test;", d);
+  query(
+      "select regex_replace('5 little monkeys climbing up 1 wall', '[0-9]', "
+      "'-') as test;",
+      d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "- little monkeys climbing up - wall");
 }
 
 TEST_F(SQLTests, test_sql_regex_replace_with_empty_pattern) {
   QueryData d;
-  query("select regex_replace('5 little monkeys climbing up 1 wall', '', '-') as test;", d);
+  query(
+      "select regex_replace('5 little monkeys climbing up 1 wall', '', '-') as "
+      "test;",
+      d);
   EXPECT_EQ(d.size(), 0);
 }
 
@@ -184,7 +190,10 @@ TEST_F(SQLTests, test_sql_regex_replace_with_empty_input) {
 
 TEST_F(SQLTests, test_sql_regex_replace_without_match) {
   QueryData d;
-  query("select regex_replace('Mama said the monkeys,not to fight|-selection_end', '[0-9]', '-') as test;", d);
+  query(
+      "select regex_replace('Mama said the monkeys,not to "
+      "fight|-selection_end', '[0-9]', '-') as test;",
+      d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "Mama said the monkeys,not to fight|-selection_end");
 }


### PR DESCRIPTION
Add a regex_replace function for SQL engine : regex_replace(`COLUMN`, `PATTERN`, `NEW_SUBSTRING`)
This function allows to replace into `COLUMN` all substings that match the POSIX regex `PATTERN` (as interpreted by boost::regex) by `NEW_SUBSTRING`.